### PR TITLE
Fix Bug and Add Edit Marker

### DIFF
--- a/src/main/java/com/rtb/projectmanagementtool/comment/CommentController.java
+++ b/src/main/java/com/rtb/projectmanagementtool/comment/CommentController.java
@@ -52,6 +52,14 @@ public final class CommentController {
     return getComments(filter, NO_QUERY_LIMIT, NO_QUERY_SORT);
   }
 
+  public ArrayList<CommentData> getComments(
+      long taskID, int limit, String sortBy, String sortDirection) {
+    Filter filter = new FilterPredicate("taskID", FilterOperator.EQUAL, taskID);
+    SortPredicate sort =
+        new SortPredicate(sortBy, SortDirection.valueOf(sortDirection.toUpperCase()));
+    return getComments(filter, limit, sort);
+  }
+
   public ArrayList<CommentData> getComments(int limit, String sortBy, String sortDirection) {
     SortPredicate sort =
         new SortPredicate(sortBy, SortDirection.valueOf(sortDirection.toUpperCase()));

--- a/src/main/java/com/rtb/projectmanagementtool/comment/CommentData.java
+++ b/src/main/java/com/rtb/projectmanagementtool/comment/CommentData.java
@@ -12,15 +12,23 @@ public final class CommentData implements Comparable<CommentData> {
   private String title;
   private String message;
   private Date timestamp;
+  private boolean isEdited;
 
   public CommentData(
-      long commentID, long taskID, long userID, String title, String message, Date timestamp) {
+      long commentID,
+      long taskID,
+      long userID,
+      String title,
+      String message,
+      Date timestamp,
+      boolean isEdited) {
     this.commentID = commentID;
     this.taskID = taskID;
     this.userID = userID;
     this.title = title;
     this.message = message;
     this.timestamp = timestamp;
+    this.isEdited = isEdited;
   }
 
   public CommentData(long taskID, long userID, String title, String message) {
@@ -30,6 +38,7 @@ public final class CommentData implements Comparable<CommentData> {
     this.title = title;
     this.message = message;
     this.timestamp = new Date();
+    this.isEdited = false;
   }
 
   public CommentData(Entity entity) {
@@ -39,6 +48,7 @@ public final class CommentData implements Comparable<CommentData> {
     title = (String) entity.getProperty("title");
     message = (String) entity.getProperty("message");
     timestamp = (Date) entity.getProperty("timestamp");
+    isEdited = (boolean) entity.getProperty("isEdited");
   }
 
   public Entity toEntity() {
@@ -53,6 +63,7 @@ public final class CommentData implements Comparable<CommentData> {
     entity.setProperty("title", title);
     entity.setProperty("message", message);
     entity.setProperty("timestamp", timestamp);
+    entity.setProperty("isEdited", isEdited);
     return entity;
   }
 
@@ -80,6 +91,10 @@ public final class CommentData implements Comparable<CommentData> {
     return timestamp;
   }
 
+  public boolean getIsEdited() {
+    return isEdited;
+  }
+
   public void setCommentID(long commentID) {
     this.commentID = commentID;
   }
@@ -104,6 +119,10 @@ public final class CommentData implements Comparable<CommentData> {
     this.timestamp = timestamp;
   }
 
+  public void setIsEdited(boolean isEdited) {
+    this.isEdited = isEdited;
+  }
+
   @Override
   public int compareTo(CommentData comment) {
     long dif = this.commentID - comment.commentID;
@@ -118,7 +137,8 @@ public final class CommentData implements Comparable<CommentData> {
     returnString += "User ID: " + userID + "\n";
     returnString += "Title: " + title + "\n";
     returnString += "Message: " + message + "\n";
-    returnString += "Date: " + timestamp + "\n}";
+    returnString += "Date: " + timestamp + "\n";
+    returnString += "Is Edited: " + isEdited + "\n}";
     return returnString;
   }
 
@@ -128,7 +148,8 @@ public final class CommentData implements Comparable<CommentData> {
         && a.userID == b.userID
         && a.title.equals(b.title)
         && a.message.equals(b.message)
-        && a.timestamp.equals(b.timestamp);
+        && a.timestamp.equals(b.timestamp)
+        && a.isEdited == b.isEdited;
   }
 
   @Override

--- a/src/main/java/com/rtb/projectmanagementtool/comment/CommentEditServlet.java
+++ b/src/main/java/com/rtb/projectmanagementtool/comment/CommentEditServlet.java
@@ -46,6 +46,9 @@ public class CommentEditServlet extends HttpServlet {
     Long userLoggedInId = auth.whichUserIsLoggedIn(request, response);
     if (userLoggedInId == comment.getUserID()) {
       // Update comment
+      if (!title.equals(comment.getTitle()) || !message.equals(comment.getMessage())) {
+        comment.setIsEdited(true);
+      }
       comment.setTitle(title);
       comment.setMessage(message);
       // Add comment to datastore

--- a/src/main/java/com/rtb/projectmanagementtool/task/TaskServlet.java
+++ b/src/main/java/com/rtb/projectmanagementtool/task/TaskServlet.java
@@ -92,13 +92,16 @@ public class TaskServlet extends HttpServlet {
     }
 
     // Get Comments
-    // int quantity = Integer.parseInt(request.getParameter("quantity"));
+    // int limit = Integer.parseInt(request.getParameter("limit"));
     // String sortBy = request.getParameter("sortBy");
     // String sortDirection = request.getParameter("sortDirection");
+    int limit = Integer.MAX_VALUE;
+    String sortBy = "timestamp";
+    String sortDirection = "descending";
     CommentController commentController = new CommentController(datastore);
     ArrayList<CommentData> comments = new ArrayList<>();
     try {
-      comments = commentController.getCommentsByTaskID(taskID);
+      comments = commentController.getComments(taskID, limit, sortBy, sortDirection);
     } catch (NullPointerException | IllegalArgumentException e) {
       System.out.println("TaskID doesn't exist. Cannot fetch comments.");
     }

--- a/src/main/webapp/scripts/task.js
+++ b/src/main/webapp/scripts/task.js
@@ -75,16 +75,22 @@ function editDescription(taskID) {
  */
 function editComment(commentID, taskID) {
   // Get DOM elements
-  const commentContainer = document.getElementById('comment-container');
-  const titleContainer = document.getElementById('comment-title-container');
-  const messageContainer = document.getElementById('comment-message-container');
-  const infoContainer = document.getElementById('comment-postinfo-container');
-  const editContainer = document.getElementById('edit-comment-container');
-  const deleteContainer = document.getElementById('delete-comment-container');
+  const commentContainer =
+      document.getElementById('comment-container-' + commentID);
+  const titleContainer =
+      document.getElementById('comment-title-container-' + commentID);
+  const messageContainer =
+      document.getElementById('comment-message-container-' + commentID);
+  const infoContainer =
+      document.getElementById('comment-postinfo-container-' + commentID);
+  const editContainer =
+      document.getElementById('edit-comment-container-' + commentID);
+  const deleteContainer =
+      document.getElementById('delete-comment-container-' + commentID);
 
   // Get attributes
-  const title = titleContainer.getElementsByTagName('h3')[0].innerText;
-  const message = messageContainer.getElementsByTagName('p')[0].innerText;
+  const title = titleContainer.innerText;
+  const message = messageContainer.innerText;
 
   // Clear DOM elements
   titleContainer.innerHTML = '';
@@ -94,7 +100,7 @@ function editComment(commentID, taskID) {
 
   // Convert comment into a form
   postForm = document.createElement('form');
-  postForm.setAttribute('id', 'edit-comment-post-form');
+  postForm.setAttribute('id', 'edit-comment-post-form-' + commentID);
   postForm.setAttribute('action', '/comment-edit');
   postForm.setAttribute('method', 'POST');
   commentContainer.appendChild(postForm);

--- a/src/main/webapp/task.jsp
+++ b/src/main/webapp/task.jsp
@@ -146,29 +146,38 @@
                 String timePattern = "HH:mm";
                 SimpleDateFormat timeFormat = new SimpleDateFormat(timePattern);
                 String time = timeFormat.format(comment.getTimestamp());
+
+                // Get isEdited
+                String edit = "";
+                if (comment.getIsEdited()) {
+                    edit = "(edited)";
+                }
+
+                // Get commentID
+                long cID = comment.getCommentID();
         %>
         <li class="comment">
-          <div id="comment-container">
-            <div id="comment-title-container"><h3><%=comment.getTitle()%></h3></div>
-            <div id="comment-postinfo-container">
+          <div id="comment-container-<%=cID%>">
+            <div id="comment-title-container-<%=cID%>"><h3><%=comment.getTitle()%></h3></div>
+            <div id="comment-postinfo-container-<%=cID%>">
               <h5>
-                Posted on <%=date%> at <%=time%>
+                Posted on <%=date%> at <%=time%> <%=edit%>
                 <br>
                 Posted by <%=username%>
               </h5>   
             </div>       
-            <div id="comment-message-container"><p><%=comment.getMessage()%></p></div>
+            <div id="comment-message-container-<%=cID%>"><p id="comment-message-<%=cID%>"><%=comment.getMessage()%></p></div>
             <% if (comment.getUserID() == user.getUserID() && task.getStatus() != Status.COMPLETE) {%>
-            <div id="edit-comment-container" class="inline">
-              <button type="button" id="edit-comment-button" class="has-hover-text flat-button" onclick="editComment(<%=comment.getCommentID()%>, <%=task.getTaskID()%>)">
+            <div id="edit-comment-container-<%=cID%>" class="inline">
+              <button type="button" id="edit-comment-button" class="has-hover-text flat-button" onclick="editComment(<%=cID%>, <%=task.getTaskID()%>)">
                 <span class="fa fa-edit" aria-hidden="true"></span>
                 <span class="hover-text small">Edit</span>
               </button>
             </div>
-            <div id="delete-comment-container" class="inline">
-              <form id="delete-comment-post-form" action="/comment-delete" method="POST" class="inline">
-                <input type="hidden" id="delete-comment-commentID-input" name="commentID" value="<%=comment.getCommentID()%>">
-                <input type="hidden" id="delete-comment-taskID-input" name="taskID" value="<%=task.getTaskID()%>">
+            <div id="delete-comment-container-<%=cID%>" class="inline">
+              <form id="delete-comment-post-form-<%=cID%>" action="/comment-delete" method="POST" class="inline">
+                <input type="hidden" id="delete-comment-commentID-input-<%=cID%>" name="commentID" value="<%=cID%>">
+                <input type="hidden" id="delete-comment-taskID-input-<%=cID%>" name="taskID" value="<%=task.getTaskID()%>">
                 <button type="submit" class="has-hover-text flat-button">
                   <span class="fa fa-trash-o" aria-hidden="true"></span>
                   <span class="hover-text small">Delete</span>

--- a/src/test/java/com/rtb/projectmanagementtool/comment/CommentDataTest.java
+++ b/src/test/java/com/rtb/projectmanagementtool/comment/CommentDataTest.java
@@ -23,6 +23,7 @@ public class CommentDataTest {
   private static final String title1 = "Comment 1";
   private static final String message1 = "Comment 1 message...";
   private static final Date timestamp1 = new Date();
+  private static final boolean isEdited1 = true;
 
   // Comment 2 attributes
   private static final long commentID2 = 2l;
@@ -31,6 +32,7 @@ public class CommentDataTest {
   private static final String title2 = "Comment 2";
   private static final String message2 = "Comment 2 message...";
   private static final Date timestamp2 = new Date();
+  private static final boolean isEdited2 = false;
 
   // Comment 3 attributes
   private static final long commentID3 = 3l;
@@ -39,6 +41,7 @@ public class CommentDataTest {
   private static final String title3 = "Comment 3";
   private static final String message3 = "Comment 3 message...";
   private static final Date timestamp3 = new Date();
+  private static final boolean isEdited3 = false;
 
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(
@@ -68,6 +71,7 @@ public class CommentDataTest {
     entity1.setProperty("title", title1);
     entity1.setProperty("message", message1);
     entity1.setProperty("timestamp", timestamp1);
+    entity1.setProperty("isEdited", isEdited1);
 
     // Build task entity 2
     Entity entity2 = new Entity("Comment");
@@ -76,6 +80,7 @@ public class CommentDataTest {
     entity2.setProperty("title", title2);
     entity2.setProperty("message", message2);
     entity2.setProperty("timestamp", timestamp2);
+    entity1.setProperty("isEdited", isEdited2);
 
     // Add task entities to ds
     ds.put(entity1);
@@ -99,7 +104,7 @@ public class CommentDataTest {
   public void testCreateCommentFromLongConstructor() {
     // Build CommentData object
     CommentData comment =
-        new CommentData(commentID1, taskID1, userID1, title1, message1, timestamp1);
+        new CommentData(commentID1, taskID1, userID1, title1, message1, timestamp1, isEdited1);
 
     // Assert CommentData parameters were stored correctly
     Assert.assertEquals("commentID", commentID1, comment.getCommentID());
@@ -108,6 +113,7 @@ public class CommentDataTest {
     Assert.assertEquals("title", title1, comment.getTitle());
     Assert.assertEquals("message", message1, comment.getMessage());
     Assert.assertEquals("timestamp", timestamp1, comment.getTimestamp());
+    Assert.assertEquals("isEdited", isEdited1, comment.getIsEdited());
   }
 
   @Test
@@ -132,6 +138,7 @@ public class CommentDataTest {
     entity.setProperty("title", title2);
     entity.setProperty("message", message2);
     entity.setProperty("timestamp", timestamp2);
+    entity.setProperty("isEdited", isEdited2);
 
     // Build CommentData object from entity
     CommentData comment = new CommentData(entity);
@@ -143,6 +150,7 @@ public class CommentDataTest {
     Assert.assertEquals("title", title2, comment.getTitle());
     Assert.assertEquals("message", message2, comment.getMessage());
     Assert.assertEquals("timestamp", timestamp2, comment.getTimestamp());
+    Assert.assertEquals("isEdited", isEdited2, comment.getIsEdited());
   }
 
   @Test
@@ -154,6 +162,7 @@ public class CommentDataTest {
     entity.setProperty("title", title2);
     entity.setProperty("message", message2);
     entity.setProperty("timestamp", timestamp2);
+    entity.setProperty("isEdited", isEdited2);
 
     // Build CommentData object from entity
     CommentData comment = new CommentData(entity);
@@ -165,13 +174,14 @@ public class CommentDataTest {
     Assert.assertEquals("title", title2, comment.getTitle());
     Assert.assertEquals("message", message2, comment.getMessage());
     Assert.assertEquals("timestamp", timestamp2, comment.getTimestamp());
+    Assert.assertEquals("isEdited", isEdited2, comment.getIsEdited());
   }
 
   @Test
   public void testCreateEntityFromComment() {
     // Build CommentData object
     CommentData comment =
-        new CommentData(commentID3, taskID3, userID3, title3, message3, timestamp3);
+        new CommentData(commentID3, taskID3, userID3, title3, message3, timestamp3, isEdited3);
 
     // Create comment entity from CommentData object
     Entity entity = comment.toEntity();
@@ -183,6 +193,7 @@ public class CommentDataTest {
     String entityTitle = (String) entity.getProperty("title");
     String entityMessage = (String) entity.getProperty("message");
     Date entityTimestamp = (Date) entity.getProperty("timestamp");
+    boolean entityIsEdited = (boolean) entity.getProperty("isEdited");
 
     // Assert comment entity attributes equal CommentData attributes
     Assert.assertEquals("commentID", commentID3, entityCommentID);
@@ -191,6 +202,7 @@ public class CommentDataTest {
     Assert.assertEquals("title", title3, entityTitle);
     Assert.assertEquals("message", message3, entityMessage);
     Assert.assertEquals("timestamp", timestamp3, entityTimestamp);
+    Assert.assertEquals("isEdited", isEdited3, entityIsEdited);
   }
 
   @Test


### PR DESCRIPTION
Another method to get comments is added to the CommentController.
CommentData has an isEdited attribute that's set to true after a comment has been edited. `(edited)` is displayed on a comment if it was edited. 
A bug that I didn't catch in my previous pull request is fixed. HTML comment element id's were equivalent for every comment, so I changed the id's to contain the commentID as well, so all of the element's id's would be unique.